### PR TITLE
xserver-xf86-config: Use openpandora override

### DIFF
--- a/recipes-graphics/xorg-xserver/xserver-xf86-config_0.1.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config_0.1.bbappend
@@ -10,12 +10,13 @@ SRC_URI_append_openpandora = " file://xorg.conf.d/10-evdev.conf \
                                  file://xorg.conf.d/99-calibration.conf \
 "
 
-CONFFILES_${PN} += "${sysconfdir}/X11/xorg.conf.d/10-evdev.conf \
+CONFFILES_${PN}_append_openpandora = "\
+                    ${sysconfdir}/X11/xorg.conf.d/10-evdev.conf \
                     ${sysconfdir}/X11/xorg.conf.d/20-omapfb.conf \
                     ${sysconfdir}/X11/xorg.conf.d/99-calibration.conf \
 "
 
-do_install_append () {
+do_install_append_openpandora () {
         install -d ${D}/${sysconfdir}/X11/xorg.conf.d/
         install -m 0644 ${WORKDIR}/xorg.conf.d/* ${D}/${sysconfdir}/X11/xorg.conf.d/
 }


### PR DESCRIPTION
Lets not nose into non-openpandaro BSPs, helps
to inter-play with projects using multiple BSP layers

Signed-off-by: Khem Raj <raj.khem@gmail.com>