### PR TITLE
xserver-xf86-config: Delete unneeded THISDIR/FILESPATH assignment

### DIFF
--- a/recipes-graphics/xorg-xserver/xserver-xf86-config_0.1.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config_0.1.bbappend
@@ -2,9 +2,6 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 # Don't forget to bump PRINC if you update the extra files.
 PRINC = "3"
 
-THISDIR := "${@os.path.dirname(bb.data.getVar('FILE', d, True))}"
-FILESPATH =. "${@base_set_filespath(["${THISDIR}/${PN}"], d)}:"
-
 SRC_URI_append_openpandora = " file://xorg.conf.d/10-evdev.conf \
                                  file://xorg.conf.d/20-omapfb.conf \
                                  file://xorg.conf.d/99-calibration.conf \


### PR DESCRIPTION
This is causing it to spill over THISDIR calculated here into other
search paths in a multi-bsp environment and as a result the other BSP
doesnt get its directories added to FILESPATH

Signed-off-by: Khem Raj raj.khem@gmail.com
